### PR TITLE
removed T1HydroCarbon from custom units

### DIFF
--- a/lua/CustomUnits/all units 1.lua
+++ b/lua/CustomUnits/all units 1.lua
@@ -58,12 +58,6 @@ UnitList = {
     T3SeaBattleship = {
         Aeon = { 'brost3bship', 50 }, -- Lupen Class (Advanced Battle Ship)
     },
-    T1HydroCarbon = {
-        UEF = { 'brnbaafac', 50 }, -- Sky-Force (HydroCarbon Anti-Air Perimeter Control System)
-        Cybran = { 'brmbt1peri', 50 }, -- Hacker (HydroCarbon Perimeter Monitoring System)
-        Aeon = { 'brobt1peri', 50 }, -- Finther (HydroCarbon Perimeter Monitoring System)
-        Seraphim = { 'xsb1107', 50 }, -- Eruya-leatoh (Hydroelectric Power Generator)
-    },
     T2LandArtillery = {
         UEF = { 'brnt2potshot', 50 }, -- Pot Shot (Medium Artillery)
     },

--- a/lua/CustomUnits/all units 2.lua
+++ b/lua/CustomUnits/all units 2.lua
@@ -32,12 +32,6 @@ UnitList = {
         Cybran = { 'brmt1btt2', 50 }, -- Reaper MK2 (Battle Tank)
         Aeon = { 'brot1mtt2', 50 }, -- Lintea MK2 (Medium Tank)
     },
-    T1HydroCarbon = {
-        UEF = { 'brnbt1peri', 50 }, -- Overlook (HydroCarbon Perimeter Monitoring System)
-        Cybran = { 'urb1107', 50 }, -- Cabin (Hydroelectric Power Generator)
-        Aeon = { 'uab1107', 50 }, -- Fordyce (Hydroelectric Power Generator)
-        Seraphim = { 'brpbt1peri', 50 }, -- Uyal Ha-Esel (HydroCarbon Perimeter Monitoring System)
-    },
     T1SeaFrigate = {
         UEF = { 'brnst1artillery', 50 }, -- Polestar Class (Artilleryship)
         Cybran = { 'brmst1battlecruiser', 50 }, -- Coelacanth Class (Battlecruiser)

--- a/lua/CustomUnits/all units 3.lua
+++ b/lua/CustomUnits/all units 3.lua
@@ -21,9 +21,6 @@ UnitList = {
         Cybran = { 'brmt2bm', 50 }, -- Cybermech (Battle Mech)
         Aeon = { 'brot2ht', 50 }, -- Gheel (Heavy Hover Tank)
     },
-    T1HydroCarbon = {
-        UEF = { 'ueb1107', 50 }, -- HPG X100 (Hydroelectric Power Generator)
-    },
     T3ArmoredAssault = {
         UEF = { 'brnt1mtt3', 50 }, -- Marmor MK3 (Medium Tank)
         Cybran = { 'brmt2abtt3', 50 }, -- Caminara MK3 (Advanced Battle Tank)


### PR DESCRIPTION
Total mayhem HydroCarbon units are too expensive to build in early stage and useless for the Ai in late game. So we don't build it.
(was eco stalling the AI at gamestart)